### PR TITLE
Added go_filters parameter which allows to specify a subset of go terms to be used as a filter

### DIFF
--- a/gopher/enrichment.py
+++ b/gopher/enrichment.py
@@ -18,6 +18,7 @@ def test_enrichment(
     species="human",
     release="current",
     fetch=False,
+    go_filters=None,
     progress=True,
 ):
     """Test for the enrichment of Gene Ontology terms from protein abundance.
@@ -48,6 +49,9 @@ def test_enrichment(
     release : str, optional
         The Gene Ontology release version. Using "current" will look up the
         most current version.
+    go_filters: List[str], optional
+        The go terms of interest. Should consists of the go term names such
+        as 'nucleus' or 'cytoplasm'.
     fetch : bool, optional
         Download the annotations even if the file already exists?
 
@@ -62,6 +66,9 @@ def test_enrichment(
         release=release,
         fetch=fetch,
     )
+
+    if go_filters:
+        annot = annot[annot["go_name"].isin(go_filters)]
 
     accessions = pd.DataFrame(
         list(proteins.index),
@@ -82,11 +89,11 @@ def test_enrichment(
     for term, accessions in tqdm(
         annot.groupby(grp_cols), disable=not progress
     ):
-        in_term = proteins.index.isin(accessions["uniprot_accession"])
+        in_term = proteins.index.isin(accessions["uniprot_accession"].unique())
         in_vals = proteins[in_term].values
         out_vals = proteins[~in_term].values
         res = stats.mannwhitneyu(in_vals, out_vals, alternative="greater")
-        results.append(list(term) + [res[1]])
+        results.append(list(term) + list(res[1]))
 
     cols = ["GO Accession", "GO Name", "GO Aspect"] + list(proteins.columns)
     results = pd.DataFrame(results, columns=cols)


### PR DESCRIPTION
Adds the ability to add a go_filter parameter to the test_enrichment function where one can optionally specify a list of terms to filter for.
There was a tiny bug which didn’t allow me to run the analysis which was fixed here: https://github.com/TalusBio/gopher/blob/small_bug_and_addition/gopher/enrichment.py#L96
Before it was
```
results.append(list(term) + [res[1]])
```
and I changed it to
```
results.append(list(term) + list(res[1]))
```
I think the result res from the mannwhitneyu test is an array if there are multiple columns and we want it to be a list. I had gotten this error when trying to create a DataFrame of the results before fixing it:
```
ValueError: 7 columns passed, passed data had 4 columns
```